### PR TITLE
Dirty xform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,10 @@ set(SPDLOG_ENABLE_PCH   ON CACHE BOOL "" FORCE)
 
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libs" FORCE)
 
+set(ASSIMP_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+set(ASSIMP_WARNINGS_AS_ERRORS OFF CACHE BOOL "" FORCE)
+
+
 FetchContent_Declare(glfw
     GIT_REPOSITORY https://github.com/glfw/glfw.git
     GIT_TAG        3.4
@@ -82,6 +86,11 @@ FetchContent_Declare(entt
     GIT_TAG        v3.15.0
 )
 
+FetchContent_Declare(assimp
+    GIT_REPOSITORY https://github.com/assimp/assimp.git
+    GIT_TAG        v5.4.3
+)
+
 #########################################################
 # Additional setup for BS_thread_pool. Header-only, no cmakelists
 FetchContent_GetProperties(BS_thread_pool)
@@ -101,7 +110,7 @@ endif()
 #########################################################
 # Only MakeAvailable projects who have cmakelists file
 #FetchContent_MakeAvailable(glfw glm glad imgui spdlog)
-FetchContent_MakeAvailable(glfw glm glew imgui spdlog entt)
+FetchContent_MakeAvailable(glfw glm glew imgui spdlog entt assimp)
 
 # Add your actual project
 add_subdirectory(rdxgraphics)

--- a/rdxgraphics/CMakeLists.txt
+++ b/rdxgraphics/CMakeLists.txt
@@ -44,4 +44,5 @@ target_link_libraries("${PROJECT_NAME}"
 	PRIVATE imgui
 	PRIVATE spdlog::spdlog
 	PRIVATE EnTT::EnTT
+	PRIVATE assimp
 )

--- a/rdxgraphics/ECS/Components/BaseComponent.cpp
+++ b/rdxgraphics/ECS/Components/BaseComponent.cpp
@@ -43,7 +43,7 @@ void Xform::SetEulerOrientation(glm::vec3 r)
 	m_Rotate = std::move(r);
 }
 
-void Xform::SetDirty()
+void Xform::SetDirty() const
 {
 	auto const& handle = GetEntityHandle();
 	if (EntityManager::HasComponent<Xform::Dirty>(handle))

--- a/rdxgraphics/ECS/Components/BaseComponent.cpp
+++ b/rdxgraphics/ECS/Components/BaseComponent.cpp
@@ -6,3 +6,48 @@ void Xform::UpdateXform()
 {
 	m_Xform = glm::translate(m_Translate) * glm::scale(m_Scale) * static_cast<glm::mat4>(glm::quat(m_Rotate));
 }
+
+glm::vec3& Xform::GetTranslate()
+{
+	SetDirty();
+	return m_Translate;
+}
+
+glm::vec3& Xform::GetScale()
+{
+	SetDirty();
+	return m_Scale;
+}
+
+glm::vec3& Xform::GetEulerOrientation()
+{
+	SetDirty();
+	return m_Rotate;
+}
+
+void Xform::SetTranslate(glm::vec3 t)
+{
+	SetDirty();
+	m_Translate = std::move(t);
+}
+
+void Xform::SetScale(glm::vec3 s)
+{
+	SetDirty();
+	m_Scale = std::move(s);
+}
+
+void Xform::SetEulerOrientation(glm::vec3 r)
+{
+	SetDirty();
+	m_Rotate = std::move(r);
+}
+
+void Xform::SetDirty()
+{
+	auto const& handle = GetEntityHandle();
+	if (EntityManager::HasComponent<Xform::Dirty>(handle))
+		return;
+
+	EntityManager::AddComponent<Xform::Dirty>(handle);
+}

--- a/rdxgraphics/ECS/Components/BaseComponent.h
+++ b/rdxgraphics/ECS/Components/BaseComponent.h
@@ -76,7 +76,7 @@ public:
 
 private:
 	inline void OnConstructImpl() { SetDirty(); }
-	void SetDirty(); // Indicates this xform to be dirty and m_Xform MUST be updated.
+	void SetDirty() const; // Indicates this xform to be dirty and m_Xform MUST be updated.
 
 private:
 	glm::vec3 m_Translate{ 0.f }, m_Scale{ 1.f }, m_Rotate{ 0.f };

--- a/rdxgraphics/ECS/Components/BaseComponent.h
+++ b/rdxgraphics/ECS/Components/BaseComponent.h
@@ -35,6 +35,9 @@ private:
 class Xform : public BaseComponent
 {
 public:
+	class Dirty : public BaseComponent {};
+
+public:
 	Xform() = default;
 	inline Xform(glm::vec3 const& pos, glm::vec3 scale = glm::vec3{1.f}, glm::vec3 eulOri = glm::vec3{0.f})
 		: m_Translate(pos), m_Scale(scale), m_Rotate(eulOri) { }

--- a/rdxgraphics/ECS/Components/BaseComponent.h
+++ b/rdxgraphics/ECS/Components/BaseComponent.h
@@ -25,9 +25,9 @@ private:
 #define RX_COMPONENT_DEC_HANDLE												\
 public:																		\
 	inline entt::entity GetEntityHandle() const { return m_Handle; }		\
+	inline void SetEntityHandle(entt::entity handle) { m_Handle = handle; } \
 private:																	\
-	entt::entity m_Handle{};												\
-	inline void SetEntityHandle(entt::entity handle) { m_Handle = handle; }
+	entt::entity m_Handle{};
 
 #define RX_COMPONENT_DEF_HANDLE(Klass)											 \
 private:																		 \

--- a/rdxgraphics/ECS/Components/BaseComponent.h
+++ b/rdxgraphics/ECS/Components/BaseComponent.h
@@ -1,16 +1,6 @@
 #pragma once
 #include <entt/entt.hpp>
 
-#define RX_COMPONENT_HAS_HANDLE(Klass) 						 \
-public:														 \
-inline static const bool HasEnttHandle{ true };				 \
-															 \
-public:														 \
-	Klass() = delete; /*We want to force the entt::entity*/	 \
-	inline Klass(entt::entity handle) : m_Handle(handle) {}; \
-	inline entt::entity GetEntityHandle() const { return m_Handle; } \
-private: entt::entity m_Handle{};
-
 // These cover all "main" components. 
 // In the context of collider, Collider is the "main", while _BV variants are the "subsidiaries"
 #define RX_DO_MAIN_COMPONENTS_M(F_O_O, ...)\
@@ -28,20 +18,18 @@ class BaseComponent
 {
 public:
 	~BaseComponent() = default;
+	inline virtual void OnConstructImpl() {};
 private:
-
 };
 
-
-
-#define RX_COMPONENT_DEC_HANDLE \
-public:							\
-	inline entt::entity GetEntityHandle() const { return m_Handle; } \
-private: \
-	entt::entity m_Handle{}; \
+#define RX_COMPONENT_DEC_HANDLE												\
+public:																		\
+	inline entt::entity GetEntityHandle() const { return m_Handle; }		\
+private:																	\
+	entt::entity m_Handle{};												\
 	inline void SetEntityHandle(entt::entity handle) { m_Handle = handle; }
-#define RX_COMPONENT_HAS_HANDLE_2(Klass)										 \
-RX_COMPONENT_DEC_HANDLE;														 \
+
+#define RX_COMPONENT_DEF_HANDLE(Klass)											 \
 private:																		 \
 	inline static void OnConstruct(entt::registry& registry, entt::entity handle)\
 	{																			 \
@@ -52,31 +40,20 @@ private:																		 \
 public:																			 \
 	inline static void Init(entt::registry& registry)							 \
 	{																			 \
-		registry.on_construct<Xform>().connect<&Xform::OnConstruct>();			 \
-		registry.on_update<Xform>().connect<&Xform::OnConstruct>();				 \
+		registry.on_construct<Klass>().connect<&Klass::OnConstruct>();			 \
+		registry.on_update<Klass>().connect<&Klass::OnConstruct>();				 \
 	}																			 \
 private:
 
+#define RX_COMPONENT_HAS_HANDLE(Klass) \
+RX_COMPONENT_DEC_HANDLE;			   \
+RX_COMPONENT_DEF_HANDLE(Klass);
 
 class Xform : public BaseComponent
 {
-	//RX_COMPONENT_HAS_HANDLE_2(Xform);
-
-public: inline entt::entity GetEntityHandle() const {
-	return m_Handle;
-} private: entt::entity m_Handle{}; inline void SetEntityHandle(entt::entity handle) {
-	m_Handle = handle;
-}; private: inline static void OnConstruct(entt::registry& registry, entt::entity handle) {
-	Xform& klass = registry.get<Xform>(handle); 
-	klass.SetEntityHandle(handle); 
-	klass.OnConstructImpl();
-} public: inline static void Init(entt::registry& registry) {
-	registry.on_construct<Xform>().connect<&Xform::OnConstruct>();
-	registry.on_update<Xform>().connect<&Xform::OnConstruct>();
-} private:;
-
+	RX_COMPONENT_HAS_HANDLE(Xform);
 public:
-	class Dirty : public BaseComponent { private: bool f{}; };
+	class Dirty : public BaseComponent { char _{}; };
 
 public:
 	Xform() = default;

--- a/rdxgraphics/ECS/Components/Camera.cpp
+++ b/rdxgraphics/ECS/Components/Camera.cpp
@@ -6,21 +6,12 @@
 #include "ECS/EntityManager.h"
 
 Camera::Camera(
-	entt::entity handle, Mode camMode,
-	glm::vec3 const& orientation,
+	Mode camMode,
 	glm::vec2 aspect, float fov)
-	: Camera(handle)
 {
 	m_AspectRatio = aspect.s / aspect.t;
 	m_FOV = fov;
 	m_CameraMode = camMode;
-
-	if (!EntityManager::HasComponent<Xform>(handle))
-	{ // Add an xform if not found
-		EntityManager::AddComponent<Xform>(handle, glm::vec3{}, glm::vec3{ 1.f }, orientation);
-	}
-
-	UpdateCameraVectors();
 
 	EventDispatcher<int, int>::RegisterEvent(RX_EVENT_FRAMEBUFFER_RESIZE,
 		[&](int x, int y)
@@ -29,8 +20,21 @@ Camera::Camera(
 		});
 }
 
+void Camera::OnConstructImpl()
+{
+	entt::entity const handle = GetEntityHandle();
+	if (!EntityManager::HasComponent<Xform>(handle))
+	{ // Add an xform if not found
+		EntityManager::AddComponent<Xform>(handle, glm::vec3{}, glm::vec3{ 1.f }, DefaultFront);
+	}
+
+	UpdateCameraVectors();
+}
+
 void Camera::UpdateCameraVectors()
 {
+	// [todo] add a camera::dirty, UpdateCameraVectors should only run if either xform or camera dirty
+
 	Xform& xform = EntityManager::GetComponent<Xform>(GetEntityHandle());
 	glm::vec3 const& position = xform.GetTranslate();
 	glm::vec3& eulerOrientation = xform.GetEulerOrientation();

--- a/rdxgraphics/ECS/Components/Camera.h
+++ b/rdxgraphics/ECS/Components/Camera.h
@@ -13,11 +13,12 @@ public:
 
 public:
 	Camera(
-		entt::entity handle, Mode camMode,
-		glm::vec3 const& orientation = DefaultFront,
+		Mode camMode,
 		glm::vec2 aspect = { 4.f, 3.f },
 		float fov = 90
 	);
+
+	void OnConstructImpl() override;
 
 	void UpdateCameraVectors();
 	void Inputs(float dt);

--- a/rdxgraphics/ECS/Components/Collider.cpp
+++ b/rdxgraphics/ECS/Components/Collider.cpp
@@ -13,11 +13,17 @@ void Collider::SetPrimitiveType(Primitive primType)
 	if (primType == Primitive::NIL)
 		return;
 
-#define _RX_X(Klass)									 \
-	case Primitive::Klass:										 \
-		EntityManager::AddComponent<Klass##Primitive>(m_Handle);\
-		RX_ASSERT(EntityManager::HasComponent<Klass##Primitive>(m_Handle));\
-		EntityManager::GetComponent<Klass##Primitive>(m_Handle).SetPosition(prevPos);\
+	SetupPrimitive(prevPos);
+}
+
+void Collider::SetupPrimitive(glm::vec3 pos) const
+{
+	entt::entity const handle = GetEntityHandle();
+#define _RX_X(Klass)															\
+	case Primitive::Klass:														\
+		EntityManager::AddComponent<Klass##Primitive>(handle);					\
+		RX_ASSERT(EntityManager::HasComponent<Klass##Primitive>(handle));		\
+		EntityManager::GetComponent<Klass##Primitive>(handle).SetPosition(pos);	\
 		break;
 
 	switch (m_PrimitiveType)
@@ -35,12 +41,13 @@ glm::vec3 Collider::RemovePrimitive()
 	if (m_PrimitiveType == Primitive::NIL)
 		return {};
 
+	entt::entity const handle = GetEntityHandle();
 	glm::vec3 pos{};
-#define _RX_X(Klass)												\
-	case Primitive::Klass:													\
-		RX_ASSERT(EntityManager::HasComponent<Klass##Primitive>(m_Handle));\
-		pos = EntityManager::GetComponent<Klass##Primitive>(m_Handle).GetPosition();\
-		EntityManager::RemoveComponent<Klass##Primitive>(m_Handle);		\
+#define _RX_X(Klass)																\
+	case Primitive::Klass:															\
+		RX_ASSERT(EntityManager::HasComponent<Klass##Primitive>(handle));			\
+		pos = EntityManager::GetComponent<Klass##Primitive>(handle).GetPosition();	\
+		EntityManager::RemoveComponent<Klass##Primitive>(handle);					\
 		break;
 
 	switch (m_PrimitiveType)

--- a/rdxgraphics/ECS/Components/Collider.cpp
+++ b/rdxgraphics/ECS/Components/Collider.cpp
@@ -74,3 +74,12 @@ void BasePrimitive::SetPosition(glm::vec3 pos)
 	glm::vec3 position = EntityManager::GetComponent<const Xform>(GetEntityHandle()).GetTranslate();
 	m_Offset = pos - position;
 }
+
+void BasePrimitive::SetDirty() const
+{
+	auto const& handle = GetEntityHandle();
+	if (EntityManager::HasComponent<Collider::Dirty>(handle))
+		return;
+
+	EntityManager::AddComponent<Collider::Dirty>(handle);
+}

--- a/rdxgraphics/ECS/Components/Collider.h
+++ b/rdxgraphics/ECS/Components/Collider.h
@@ -5,6 +5,9 @@ class Collider : public BaseComponent
 {
 	RX_COMPONENT_HAS_HANDLE(Collider);
 public:
+	class Dirty : public BaseComponent { char _{}; };
+
+public:
 	inline Collider(Primitive primType = Primitive::NIL) : m_PrimitiveType(primType) { }
 	inline void OnConstructImpl() override { SetupPrimitive(); }
 
@@ -21,53 +24,63 @@ private:
 
 class BasePrimitive : public BaseComponent
 {
+	RX_COMPONENT_DEC_HANDLE;
 public:
 	BasePrimitive() = default;
 	~BasePrimitive() = default;
-	inline BasePrimitive(glm::vec3 const& p) : m_Position(p) {}
-	inline BasePrimitive(float x, float y, float z) : m_Position({ x, y, z }) {}
+	inline BasePrimitive(glm::vec3 const& o) : m_Offset(o) {}
+	inline BasePrimitive(float x, float y, float z) : m_Offset({ x, y, z }) {}
+
+	// Can be overrided again if needed, but call BasePrimitive::OnConstructImpl() first
+	inline void OnConstructImpl() override { SetDirty(); }
 
 	virtual void UpdateXform() = 0;
 
 	inline glm::mat4 const& GetXform() const { return m_Xform; }
-	inline glm::vec3 const& GetPosition() const { return m_Position; }
-	inline glm::vec3& GetPosition() { return m_Position; }
-	inline void SetPosition(glm::vec3 pos) { m_Position = pos; }
+	inline glm::vec3 const& GetOffset() const { return m_Offset; }
+	inline glm::vec3& GetOffset() { SetDirty(); return m_Offset; }
+	inline void SetOffset(glm::vec3 o) { SetDirty(); m_Offset = o; }
+
+	glm::vec3 GetPosition() const;
+	void SetPosition(glm::vec3 pos);
+
 	inline bool const& IsCollide() const { return m_IsCollide; }
 	inline bool& IsCollide() { return m_IsCollide; }
-	inline bool const& IsFollowXform() const { return m_IsFollowXform; }
-	inline bool& IsFollowXform() { return m_IsFollowXform; }
+
+	void SetDirty() const {};
 
 protected:
 	glm::mat4 m_Xform{};
-	glm::vec3 m_Position{};
+
+private:
+	glm::vec3 m_Offset{};
 	bool m_IsCollide{ false };
-	bool m_IsFollowXform{ true };
 };
 
 class PointPrimitive : public BasePrimitive
 {
+	RX_COMPONENT_DEF_HANDLE(PointPrimitive);
 public:
 	PointPrimitive() = default;
-	inline PointPrimitive(glm::vec3 const& p) : BasePrimitive(p) {}
+	inline PointPrimitive(glm::vec3 const& o) : BasePrimitive(o) {}
 	inline PointPrimitive(float x, float y, float z) : BasePrimitive(x, y, z) {}
 
 	inline void UpdateXform() override
 	{
-		m_Xform = glm::translate(m_Position);
+		m_Xform = glm::translate(GetPosition());
 	}
 };
 
 class RayPrimitive : public BasePrimitive
 {
+	RX_COMPONENT_DEF_HANDLE(RayPrimitive);
 public:
 	inline static const glm::vec3 DefaultDirection{ 0.f,0.f,-1.f };
 public:
 	RayPrimitive() = default;
 	inline void UpdateXform() override
 	{
-		//RX_INFO("{} > {} > {}", GetDirection().x, GetDirection().y, GetDirection().z);
-		m_Xform = glm::translate(m_Position) * glm::scale(glm::vec3{ s_Scale }) *
+		m_Xform = glm::translate(GetPosition()) * glm::scale(glm::vec3{ s_Scale }) *
 			glm::mat4_cast(GetOrientationQuat());
 	}
 
@@ -90,6 +103,7 @@ private:
 // Must be CCW orientation
 class TrianglePrimitive : public BasePrimitive
 {
+	RX_COMPONENT_DEF_HANDLE(TrianglePrimitive);
 public:
 	inline static const glm::vec3 DefaultP0{ 0.0f,		 1.0f, 0.f };
 	inline static const glm::vec3 DefaultP1{ -0.86603f,	-0.5f, 0.f };
@@ -115,17 +129,18 @@ public:
 	inline void UpdateCentroid()
 	{
 		static float one_third = 1.f / 3.f;
-		glm::vec3 oldCentroid = m_Position;
+		glm::vec3 oldCentroid = GetPosition();
 		glm::vec3 p0_w = oldCentroid + m_P0;
 		glm::vec3 p1_w = oldCentroid + m_P1;
 		glm::vec3 p2_w = oldCentroid + m_P2;
-
-		m_Position = one_third * (p0_w + p1_w + p2_w);
-
+		
+		glm::vec3 newCentroid = one_third * (p0_w + p1_w + p2_w);
+		SetPosition(newCentroid); // Updates m_Offset
+		
 		// Update the local offsets since centroid changed
-		m_P0 = p0_w - m_Position;
-		m_P1 = p1_w - m_Position;
-		m_P2 = p2_w - m_Position;
+		m_P0 = p0_w - newCentroid;
+		m_P1 = p1_w - newCentroid;
+		m_P2 = p2_w - newCentroid;
 	}
 
 	inline glm::vec3 const& GetP0() const { return m_P0; }
@@ -135,9 +150,9 @@ public:
 	inline glm::vec3 const& GetP2() const { return m_P2; }
 	inline glm::vec3& GetP2() { return m_P2; }
 
-	inline glm::vec3 GetP0_W() const { return m_Position + m_P0; }
-	inline glm::vec3 GetP1_W() const { return m_Position + m_P1; }
-	inline glm::vec3 GetP2_W() const { return m_Position + m_P2; }
+	inline glm::vec3 GetP0_W() const { return GetPosition() + m_P0; }
+	inline glm::vec3 GetP1_W() const { return GetPosition() + m_P1; }
+	inline glm::vec3 GetP2_W() const { return GetPosition() + m_P2; }
 
 private: // These points are OFFSETS from the centroid (position)
 	glm::vec3 m_P0{ DefaultP0 };
@@ -147,15 +162,16 @@ private: // These points are OFFSETS from the centroid (position)
 
 class PlanePrimitive : public BasePrimitive
 {
+	RX_COMPONENT_DEF_HANDLE(PlanePrimitive);
 public:
 	inline static const glm::vec3 DefaultNormal{ 0.f,0.f,1.f };
 	inline static const uint32_t DefaultSize{ 40 };
 public:
 	PlanePrimitive() = default;
-	inline PlanePrimitive(glm::vec3 p, glm::vec3 const& eulerOrientation) : BasePrimitive(p), m_EulerOrientation(eulerOrientation) {}
+	inline PlanePrimitive(glm::vec3 o, glm::vec3 const& eulerOrientation) : BasePrimitive(o), m_EulerOrientation(eulerOrientation) {}
 	inline void UpdateXform() override
 	{
-		m_Xform = glm::translate(m_Position) * glm::scale(s_Scale) *
+		m_Xform = glm::translate(GetPosition()) * glm::scale(s_Scale) *
 			glm::mat4_cast(glm::quat{ m_EulerOrientation });
 	}
 
@@ -178,32 +194,33 @@ private:
 
 class AABBPrimitive : public BasePrimitive
 {
+	RX_COMPONENT_DEF_HANDLE(AABBPrimitive);
 public:
 	AABBPrimitive() = default;
 	inline void UpdateXform() override
 	{
-		m_Xform = glm::translate(m_Position) * glm::scale(m_HalfExtents);
+		m_Xform = glm::translate(GetPosition()) * glm::scale(m_HalfExtents);
 	}
 
 	inline glm::vec3 const& GetHalfExtents() const { return m_HalfExtents; }
 	inline glm::vec3& GetHalfExtents() { return m_HalfExtents; }
-	inline glm::vec3 GetMinPoint() const { return m_Position - 0.5f * m_HalfExtents; }
-	inline glm::vec3 GetMaxPoint() const { return m_Position + 0.5f * m_HalfExtents; }
+	inline glm::vec3 GetMinPoint() const { return GetPosition() - 0.5f * m_HalfExtents; }
+	inline glm::vec3 GetMaxPoint() const { return GetPosition() + 0.5f * m_HalfExtents; }
 
 private:
 	glm::vec3 m_HalfExtents{ 0.5f };
-
 };
 
 class SpherePrimitive : public BasePrimitive
 {
+	RX_COMPONENT_DEF_HANDLE(SpherePrimitive);
 public:
 	SpherePrimitive() = default;
-	inline SpherePrimitive(glm::vec3 const& p, float r) : BasePrimitive(p), m_Radius(r) {}
+	inline SpherePrimitive(glm::vec3 const& o, float r) : BasePrimitive(o), m_Radius(r) {}
 
 	inline void UpdateXform() override
 	{
-		m_Xform = glm::translate(m_Position) * glm::scale(glm::vec3{ m_Radius });
+		m_Xform = glm::translate(GetPosition()) * glm::scale(glm::vec3{ m_Radius });
 	}
 
 	inline float const& GetRadius() const { return m_Radius; }

--- a/rdxgraphics/ECS/Components/Collider.h
+++ b/rdxgraphics/ECS/Components/Collider.h
@@ -47,7 +47,7 @@ public:
 	inline bool const& IsCollide() const { return m_IsCollide; }
 	inline bool& IsCollide() { return m_IsCollide; }
 
-	void SetDirty() const {};
+	void SetDirty() const;
 
 protected:
 	glm::mat4 m_Xform{};

--- a/rdxgraphics/ECS/Components/Collider.h
+++ b/rdxgraphics/ECS/Components/Collider.h
@@ -5,10 +5,14 @@ class Collider : public BaseComponent
 {
 	RX_COMPONENT_HAS_HANDLE(Collider);
 public:
-	inline Collider(entt::entity handle, Primitive primType) : Collider(handle) { SetPrimitiveType(primType); }
+	inline Collider(Primitive primType = Primitive::NIL) : m_PrimitiveType(primType) { }
+	inline void OnConstructImpl() override { SetupPrimitive(); }
 
 	inline Primitive GetPrimitiveType() const { return m_PrimitiveType; }
 	void SetPrimitiveType(Primitive primType);
+
+private:
+	void SetupPrimitive(glm::vec3 pos = glm::vec3{0.f}) const;
 	glm::vec3 RemovePrimitive(); // returns position of removed BV
 
 private:

--- a/rdxgraphics/ECS/EntityManager.cpp
+++ b/rdxgraphics/ECS/EntityManager.cpp
@@ -10,6 +10,10 @@ bool EntityManager::Init()
 	Camera::Init(g.m_Registry);
 	Collider::Init(g.m_Registry);
 
+#define _RX_X(Klass) Klass##Primitive::Init(g.m_Registry);
+	RX_DO_ALL_BV_ENUM;
+#undef _RX_X
+
 	return true;
 }
 

--- a/rdxgraphics/ECS/EntityManager.cpp
+++ b/rdxgraphics/ECS/EntityManager.cpp
@@ -1,11 +1,14 @@
 #include <pch.h>
 #include "EntityManager.h"
+#include "Components.h"
 
 RX_SINGLETON_EXPLICIT(EntityManager);
 
 bool EntityManager::Init()
 {
 	Xform::Init(g.m_Registry);
+	Camera::Init(g.m_Registry);
+	Collider::Init(g.m_Registry);
 
 	return true;
 }

--- a/rdxgraphics/ECS/EntityManager.cpp
+++ b/rdxgraphics/ECS/EntityManager.cpp
@@ -5,6 +5,8 @@ RX_SINGLETON_EXPLICIT(EntityManager);
 
 bool EntityManager::Init()
 {
+	Xform::Init(g.m_Registry);
+
 	return true;
 }
 

--- a/rdxgraphics/ECS/Systems/CollisionSystem.h
+++ b/rdxgraphics/ECS/Systems/CollisionSystem.h
@@ -60,5 +60,7 @@ private:
 	static bool CheckCollision(SpherePrimitive const& lhs, SpherePrimitive const& rhs);
 
 public: // Helper functions, most of these are directly from the orange textbook
+	static bool IntersectPointTriangle(glm::vec3 const& p, glm::vec3 const& q0, glm::vec3 const& q1, glm::vec3 const& q2, glm::vec3 const& qn);
+	static bool IntersectPointSphere(glm::vec3 const& p, glm::vec3 const& q, float radius);
 	static bool IntersectSegmentPlane(RayPrimitive const& ray, PlanePrimitive const& plane, PointPrimitive* oPoint = nullptr);
 };

--- a/rdxgraphics/ECS/Systems/TransformSystem.cpp
+++ b/rdxgraphics/ECS/Systems/TransformSystem.cpp
@@ -24,11 +24,11 @@ void TransformSystem::Update(float dt)
 			continue;
 
 		Xform const& xform = EntityManager::GetComponent<const Xform>(handle);
-#define _RX_X(Klass)														 \
-		case Primitive::Klass:														 \
-		{																	 \
-			Klass##Primitive& bv = EntityManager::GetComponent<Klass##Primitive>(handle);  \
-			if (bv.IsFollowXform()) bv.GetPosition() = xform.GetTranslate(); \
+#define _RX_X(Klass)																		\
+		case Primitive::Klass:																\
+		{																					\
+			Klass##Primitive& bv = EntityManager::GetComponent<Klass##Primitive>(handle);	\
+			if (bv.IsFollowXform()) bv.GetPosition() = xform.GetTranslate();				\
 		} break;
 
 		switch (col.GetPrimitiveType())
@@ -39,12 +39,12 @@ void TransformSystem::Update(float dt)
 		}
 #undef _RX_X
 
-#define _RX_X(Klass)													\
-	case Primitive::Klass:														\
-	{																	\
-		/*Should check ensure that get<BV> exists*/						\
+#define _RX_X(Klass)																	\
+	case Primitive::Klass:																\
+	{																					\
+		/*Should check ensure that get<BV> exists*/										\
 		Klass##Primitive& bv = EntityManager::GetComponent<Klass##Primitive>(handle);	\
-		bv.UpdateXform();												\
+		bv.UpdateXform();																\
 	} break;
 
 		switch (col.GetPrimitiveType())

--- a/rdxgraphics/ECS/Systems/TransformSystem.cpp
+++ b/rdxgraphics/ECS/Systems/TransformSystem.cpp
@@ -33,7 +33,7 @@ void TransformSystem::Update(float dt)
 
 		switch (col.GetPrimitiveType())
 		{
-			RX_DO_ALL_BV_ENUM;
+			//RX_DO_ALL_BV_ENUM;
 		default:
 			break;
 		}

--- a/rdxgraphics/ECS/Systems/TransformSystem.cpp
+++ b/rdxgraphics/ECS/Systems/TransformSystem.cpp
@@ -7,10 +7,14 @@ RX_SINGLETON_EXPLICIT(TransformSystem);
 
 void TransformSystem::Update(float dt)
 {
-	auto xformView = EntityManager::View<Xform>();
-	for (auto [handle, xform] : xformView.each())
+	auto xformView = EntityManager::View<Xform, Xform::Dirty, Metadata>();
+	int i = 0;
+	for (auto [handle, xform, dirty, meta] : xformView.each())
 	{
 		xform.UpdateXform();
+		EntityManager::RemoveComponent<Xform::Dirty>(handle);
+		RX_INFO("{}, {}", i, meta.GetName());
+		++i;
 	}
 
 	auto colView = EntityManager::View<const Xform, const Collider>();
@@ -19,7 +23,7 @@ void TransformSystem::Update(float dt)
 		if (col.GetPrimitiveType() == Primitive::NIL)
 			continue;
 
-		Xform& xform = EntityManager::GetComponent<Xform>(handle);
+		Xform const& xform = EntityManager::GetComponent<const Xform>(handle);
 #define _RX_X(Klass)														 \
 		case Primitive::Klass:														 \
 		{																	 \

--- a/rdxgraphics/GSM/Scenes/Assignment1/Assignment1.cpp
+++ b/rdxgraphics/GSM/Scenes/Assignment1/Assignment1.cpp
@@ -115,7 +115,7 @@ void AABBXAABBScene::StartImpl()
 		EntityManager::AddComponent<Xform>(handle, glm::vec3{ 0.f }, glm::vec3{ 0.5f });
 		EntityManager::AddComponent<Model>(handle, Shape::Cube);
 		EntityManager::AddComponent<Material>(handle, glm::vec3{ 0.f, 0.f, 1.f });
-		EntityManager::AddComponent<Collider>(handle, Primitive::Sphere);
+		EntityManager::AddComponent<Collider>(handle, Primitive::AABB);
 		EntityManager::GetComponent<AABBPrimitive>(handle).GetHalfExtents() = glm::vec3{ 1.5f };
 
 		GUI::SetSelectedEntity(handle);

--- a/rdxgraphics/GSM/Scenes/CommonLayer.cpp
+++ b/rdxgraphics/GSM/Scenes/CommonLayer.cpp
@@ -7,7 +7,7 @@
 void CommonLayer::StartImpl()
 {
 	{
-		auto handle = BaseScene::CreateDefaultEntity<NoDelete>();
+		entt::entity handle = m_LightHandle = BaseScene::CreateDefaultEntity<NoDelete>();
 		EntityManager::AddComponent<Metadata>(handle, "Directional Light");
 		EntityManager::AddComponent<Xform>(handle, glm::vec3{ 0.f, 5.f, 0.f }, glm::vec3{ 0.3f });
 		EntityManager::AddComponent<Model>(handle, Shape::Cube);
@@ -17,31 +17,29 @@ void CommonLayer::StartImpl()
 	{
 		entt::entity handle = m_MainCamera = BaseScene::CreateDefaultEntity<NoDelete>();
 		EntityManager::AddComponent<Metadata>(handle, "FPS Cam");
-		EntityManager::AddComponent<Model>(handle, Shape::Cube);
-		EntityManager::AddComponent<Material>(handle, glm::vec3{ 1.f,1.f,0.f });
-		EntityManager::AddComponent<Camera>(handle,
-			Camera::Mode::Perspective,
-			glm::vec3{},
-			glm::vec2{ 16.f, 9.f }, 90.f);
 		EntityManager::AddComponent<Xform>(handle,
 			glm::vec3{ -3.f, 3.f, 3.f },
 			glm::vec3{ 0.2f },
 			glm::vec3{ -0.7f, -0.7f, 0.f });
+		EntityManager::AddComponent<Model>(handle, Shape::Cube);
+		EntityManager::AddComponent<Material>(handle, glm::vec3{ 1.f,1.f,0.f });
+		EntityManager::AddComponent<Camera>(handle,
+			Camera::Mode::Perspective,
+			glm::vec2{ 16.f, 9.f }, 90.f);
 	}
 
 	{
 		entt::entity handle = m_MinimapCamera = BaseScene::CreateDefaultEntity<NoDelete>();
 		EntityManager::AddComponent<Metadata>(handle, "PiP Cam");
-		EntityManager::AddComponent<Model>(handle, Shape::Cube);
-		EntityManager::AddComponent<Material>(handle, glm::vec3{ 1.f,1.f,0.f });
-		EntityManager::AddComponent<Camera>(handle,
-			Camera::Mode::Orthorgonal,
-			glm::vec3{},
-			glm::vec2{ 16.f, 9.f }, 90.f);
 		EntityManager::AddComponent<Xform>(handle,
 			glm::vec3{ 0.f, 5.f, 0.f },
 			glm::vec3{ 0.2f },
 			glm::vec3{ -glm::half_pi<float>() + glm::epsilon<float>(), 0.f, 0.f });
+		EntityManager::AddComponent<Model>(handle, Shape::Cube);
+		EntityManager::AddComponent<Material>(handle, glm::vec3{ 1.f,1.f,0.f });
+		EntityManager::AddComponent<Camera>(handle,
+			Camera::Mode::Orthorgonal,
+			glm::vec2{ 16.f, 9.f }, 90.f);
 	}
 
 	m_ActiveCamera = m_MainCamera;
@@ -65,6 +63,7 @@ void CommonLayer::UpdateImpl(float dt)
 		cam.Inputs(dt);
 
 	// PiP following FPS's X/Z
+	if (EntityManager::HasComponent<Xform::Dirty>(cam.GetEntityHandle()))
 	{
 		auto [xform, pip] = EntityManager::GetComponent<Xform, Camera>(RenderSystem::GetMinimapCamera());
 		auto& pos = xform.GetTranslate();
@@ -76,19 +75,19 @@ void CommonLayer::UpdateImpl(float dt)
 	// Directional light moving in a circle
 	{
 		static float angle = 0.f;
-		auto view = EntityManager::View<Xform, DirectionalLight>();
-		for (auto [handle, xform, light] : view.each())
-		{
-			float rate = 0.25f;
-			float radius = 5.f;
-			angle += glm::two_pi<float>() * rate * dt;
-			if (angle > glm::two_pi<float>()) angle = 0.f;
+		auto& xform = EntityManager::GetComponent<Xform>(m_LightHandle);
+		auto& light = EntityManager::GetComponent<DirectionalLight>(m_LightHandle);
+		
+		const float rate = 0.25f;
+		const float radius = 5.f;
+		angle += glm::two_pi<float>() * rate * dt;
+		if (angle > glm::two_pi<float>()) angle = 0.f;
 
-			xform.GetTranslate().x = glm::cos(angle) * radius;
-			xform.GetTranslate().y = 0.f;
-			xform.GetTranslate().z = glm::sin(angle) * radius;
+		auto& pos = xform.GetTranslate();
+		pos.x = glm::cos(angle) * radius;
+		pos.y = 0.f;
+		pos.z = glm::sin(angle) * radius;
 
-			light.GetDirection() = glm::normalize(-xform.GetTranslate()); // Look at origin
-		}
+		light.GetDirection() = glm::normalize(-xform.GetTranslate()); // Look at origin
 	}
 }

--- a/rdxgraphics/GSM/Scenes/CommonLayer.h
+++ b/rdxgraphics/GSM/Scenes/CommonLayer.h
@@ -13,4 +13,5 @@ private:
 
 	entt::entity m_MainCamera{};
 	entt::entity m_MinimapCamera{};
+	entt::entity m_LightHandle{};
 };

--- a/rdxgraphics/GUI/Windows/Inspector.cpp
+++ b/rdxgraphics/GUI/Windows/Inspector.cpp
@@ -116,7 +116,7 @@ void Inspector::UpdateCompMaterial(std::string const& strHandle, Material& comp)
 
 void Inspector::UpdateCompCollider(std::string const& strHandle, Collider& comp)
 {
-	ImGui::Text("Choose BV type");
+	ImGui::Text("Choose Primitive");
 	entt::entity handle = comp.GetEntityHandle();
 
 #define _RX_X(Klass) #Klass,
@@ -127,7 +127,7 @@ void Inspector::UpdateCompCollider(std::string const& strHandle, Collider& comp)
 
 	size_t currIndex = (size_t)comp.GetPrimitiveType();
 	ImGuiComboFlags comboFlags = 0;
-	if (ImGui::BeginCombo("BV Type", bvOptions[currIndex].c_str(), comboFlags))
+	if (ImGui::BeginCombo("Primitive", bvOptions[currIndex].c_str(), comboFlags))
 	{
 		for (size_t i = 0; i < bvOptions.size(); ++i)
 		{
@@ -146,8 +146,7 @@ void Inspector::UpdateCompCollider(std::string const& strHandle, Collider& comp)
 		RX_ASSERT(EntityManager::HasComponent<Klass##Primitive>(handle));					\
 		if (ImGui::TreeNodeEx(#Klass" Primitive")) {										\
 			Klass##Primitive& comp = EntityManager::GetComponent<Klass##Primitive>(handle);	\
-			ImGui::Checkbox("Follow Xform", &comp.IsFollowXform());							\
-			PositionDrag(strHandle, comp.GetPosition());									\
+			PositionDrag(strHandle, comp.GetOffset());										\
 			UpdateComp##Klass##Primitive(strHandle, comp);									\
 			ImGui::TreePop();																\
 		}																					\

--- a/rdxgraphics/RDX.cpp
+++ b/rdxgraphics/RDX.cpp
@@ -21,6 +21,7 @@ void RDX::Run()
 
 	bool initOK = true;
 	initOK &= GLFWWindow::Init();
+	initOK &= EntityManager::Init();
 	initOK &= RenderSystem::Init();
 	initOK &= GUI::Init();
 	if (!initOK)


### PR DESCRIPTION
Adds a ::Dirty class for both Xform and Collider. This allows for slightly more efficient Xform system, where we don't waste time recalculating Xforms which have not changed (dirty). This branch also includes changes converting Colliders' position to be an offset instead. Much more intuitive user-wise